### PR TITLE
Fix zombie caused when resizing down orientation

### DIFF
--- a/UIImage+Resize.m
+++ b/UIImage+Resize.m
@@ -59,6 +59,8 @@
 - (CGImageRef) CGImageWithCorrectOrientation
 {
     if (self.imageOrientation == UIImageOrientationDown) {
+        //retaining because caller expects to own the reference
+        CGImageRetain([self CGImage]);
         return [self CGImage];
     }
     UIGraphicsBeginImageContext(self.size);


### PR DESCRIPTION
Previous memory leak fix introduced a new bug when resizing image having UIImageOrientationDown.

Other orientations return an image created with: CGBitmapContextCreateImage()
Thus, the caller owns the ImageRef

Down orientation returns existing self CGImage unaltered, thus not owned by caller.
