### PR TITLE
Use integerValue instead of unsignedIntegerValue

### DIFF
--- a/UIImage+ResizeMagick.h
+++ b/UIImage+ResizeMagick.h
@@ -11,8 +11,8 @@
 @interface UIImage (ResizeMagick)
 
 - (UIImage *) resizedImageByMagick: (NSString *) spec;
-- (UIImage *) resizedImageByWidth:  (NSUInteger) width;
-- (UIImage *) resizedImageByHeight: (NSUInteger) height;
+- (UIImage *) resizedImageByWidth:  (NSInteger) width;
+- (UIImage *) resizedImageByHeight:  (NSInteger) height;
 - (UIImage *) resizedImageWithMaximumSize: (CGSize) size;
 - (UIImage *) resizedImageWithMinimumSize: (CGSize) size;
 

--- a/UIImage+ResizeMagick.m
+++ b/UIImage+ResizeMagick.m
@@ -23,8 +23,8 @@
     if([spec hasSuffix:@"!"]) {
         NSString *specWithoutSuffix = [spec substringToIndex: [spec length] - 1];
         NSArray *widthAndHeight = [specWithoutSuffix componentsSeparatedByString: @"x"];
-        NSUInteger width = [[widthAndHeight objectAtIndex: 0] unsignedIntegerValue];
-        NSUInteger height = [[widthAndHeight objectAtIndex: 1] unsignedIntegerValue];
+        NSInteger width = [[widthAndHeight objectAtIndex: 0] integerValue];
+        NSInteger height = [[widthAndHeight objectAtIndex: 1] integerValue];
         UIImage *newImage = [self resizedImageWithMinimumSize: CGSizeMake (width, height)];
         return [newImage drawImageInBounds: CGRectMake (0, 0, width, height)];
     }
@@ -32,8 +32,8 @@
     if([spec hasSuffix:@"#"]) {
         NSString *specWithoutSuffix = [spec substringToIndex: [spec length] - 1];
         NSArray *widthAndHeight = [specWithoutSuffix componentsSeparatedByString: @"x"];
-        NSUInteger width = [[widthAndHeight objectAtIndex: 0] unsignedIntegerValue];
-        NSUInteger height = [[widthAndHeight objectAtIndex: 1] unsignedIntegerValue];
+        NSInteger width = [[widthAndHeight objectAtIndex: 0] integerValue];
+        NSInteger height = [[widthAndHeight objectAtIndex: 1] integerValue];
         UIImage *newImage = [self resizedImageWithMinimumSize: CGSizeMake (width, height)];
         return [newImage croppedImageWithRect: CGRectMake ((newImage.size.width - width) / 2, (newImage.size.height - height) / 2, width, height)];
     }
@@ -50,7 +50,7 @@
         return [self resizedImageByWidth: [spec integerValue]];
     }
     if ([[widthAndHeight objectAtIndex: 0] isEqualToString: @""]) {
-        return [self resizedImageByHeight: [[widthAndHeight objectAtIndex: 1] unsignedIntegerValue]];
+        return [self resizedImageByHeight: [[widthAndHeight objectAtIndex: 1] integerValue]];
     }
     return [self resizedImageWithMaximumSize: CGSizeMake ([[widthAndHeight objectAtIndex: 0] longLongValue],
                                                           [[widthAndHeight objectAtIndex: 1] longLongValue])];
@@ -60,7 +60,7 @@
 {
     if (self.imageOrientation == UIImageOrientationDown) {
         //retaining because caller expects to own the reference
-		CGImageRef cgImage = [self CGImage];
+        CGImageRef cgImage = [self CGImage];
         CGImageRetain(cgImage);
         return cgImage;
     }
@@ -85,7 +85,7 @@
 }
 
 
-- (UIImage *) resizedImageByWidth:  (NSUInteger) width
+- (UIImage *) resizedImageByWidth:  (NSInteger) width
 {
     CGImageRef imgRef = [self CGImageWithCorrectOrientation];
     CGFloat original_width  = CGImageGetWidth(imgRef);
@@ -95,7 +95,7 @@
     return [self drawImageInBounds: CGRectMake(0, 0, width, round(original_height * ratio))];
 }
 
-- (UIImage *) resizedImageByHeight:  (NSUInteger) height
+- (UIImage *) resizedImageByHeight:  (NSInteger) height
 {
     CGImageRef imgRef = [self CGImageWithCorrectOrientation];
     CGFloat original_width  = CGImageGetWidth(imgRef);


### PR DESCRIPTION
`unsignedIntegerValue` is not available on `NSString
(NSStringExtensionMethods)` so it throws and exception when used, while
`integerValue` and `longLongValue` work nicely.

```objc
// NSString.h

@property (readonly) NSInteger integerValue NS_AVAILABLE(10_5, 2_0);
@property (readonly) long long longLongValue NS_AVAILABLE(10_5, 2_0);
```